### PR TITLE
DO NOT MERGE TO MASTER

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    tunemygc (1.0.69)
+    tunemygc (1.0.69.pre.shopify)
 
 GEM
   remote: https://rubygems.org/
@@ -138,4 +138,4 @@ DEPENDENCIES
   webmock (~> 1.2, >= 1.2.0)
 
 BUNDLED WITH
-   1.13.6
+   1.15.1

--- a/Rakefile
+++ b/Rakefile
@@ -29,5 +29,4 @@ namespace :debug do
   end
 end
 
-task :test => :compile
-task :default => :test
+task :default => :compile

--- a/ext/tunemygc/extconf.rb
+++ b/ext/tunemygc/extconf.rb
@@ -31,6 +31,7 @@ if gc_events
     gc_latest_info.each do |key, val|
       f.puts "    VALUE #{key};"
     end
+    f.puts "    void *next;"
     f.puts '} tunemygc_stat_record;'
 
     f.puts "static void"
@@ -44,6 +45,7 @@ if gc_events
         f.puts "    record->#{k} = rb_gc_latest_gc_info(sym_latest_gc_info[#{i}]);"
       }
       #
+    f.puts "    record->next = NULL;"
     f.puts "}"
 
     f.puts "static VALUE"

--- a/ext/tunemygc/tunemygc_ext.c
+++ b/ext/tunemygc/tunemygc_ext.c
@@ -132,7 +132,11 @@ static void tunemygc_gc_hook_i(VALUE tpval, void *data)
         if (!rb_postponed_job_register(0, tunemygc_invoke_gc_snapshot, (void *)stat)) {
             fprintf(stderr, "[TuneMyGc.ext] Failed enqueing rb_postponed_job_register, disabling!\n");
             disabled = 1;
-            free(stat);
+            while(stat != NULL) {
+                tunemygc_stat_record *next = (tunemygc_stat_record *)stat->next;
+                free(stat);
+                stat = next;
+            }
         }
         current_cycle = NULL;
     }

--- a/ext/tunemygc/tunemygc_ext.c
+++ b/ext/tunemygc/tunemygc_ext.c
@@ -18,7 +18,7 @@ static double _tunemygc_walltime()
 {
   struct timespec ts;
 #ifdef HAVE_CLOCK_GETTIME
-  if (clock_gettime(CLOCK_REALTIME, &ts) == -1) {
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1) {
     rb_sys_fail("clock_gettime");
   }
 #else

--- a/ext/tunemygc/tunemygc_ext.c
+++ b/ext/tunemygc/tunemygc_ext.c
@@ -5,7 +5,8 @@ static ID id_tunemygc_tracepoint;
 static ID id_tunemygc_raw_snapshot;
 
 static VALUE sym_gc_cycle_started;
-static VALUE sym_gc_cycle_ended;
+static VALUE sym_gc_cycle_mark_ended;
+static VALUE sym_gc_cycle_sweep_ended;
 
 /* For 2.2.x incremental GC */
 #ifdef RUBY_INTERNAL_EVENT_GC_ENTER
@@ -72,8 +73,11 @@ static void tunemygc_gc_hook_i(VALUE tpval, void *data)
         case RUBY_INTERNAL_EVENT_GC_START:
             stat->stage = sym_gc_cycle_started;
             break;
+        case RUBY_INTERNAL_EVENT_GC_END_MARK:
+            stat->stage = sym_gc_cycle_mark_ended;
+            break;
         case RUBY_INTERNAL_EVENT_GC_END_SWEEP:
-            stat->stage = sym_gc_cycle_ended;
+            stat->stage = sym_gc_cycle_sweep_ended;
             break;
 #ifdef RUBY_INTERNAL_EVENT_GC_ENTER
         case RUBY_INTERNAL_EVENT_GC_ENTER:
@@ -142,7 +146,8 @@ void Init_tunemygc_ext()
 
     /* Symbol warmup */
     sym_gc_cycle_started = ID2SYM(rb_intern("GC_CYCLE_STARTED"));
-    sym_gc_cycle_ended = ID2SYM(rb_intern("GC_CYCLE_ENDED"));
+    sym_gc_cycle_mark_ended = ID2SYM(rb_intern("GC_CYCLE_MARK_ENDED"));
+    sym_gc_cycle_sweep_ended = ID2SYM(rb_intern("GC_CYCLE_SWEEP_ENDED"));
 
     /* For 2.2.x incremental GC */
 #ifdef RUBY_INTERNAL_EVENT_GC_ENTER

--- a/ext/tunemygc/tunemygc_ext.c
+++ b/ext/tunemygc/tunemygc_ext.c
@@ -113,8 +113,14 @@ static void tunemygc_gc_hook_i(VALUE tpval, void *data)
         case RUBY_INTERNAL_EVENT_GC_ENTER:
             stat->stage = sym_gc_cycle_entered;
             if (current_cycle != NULL) {
-                fprintf(stderr, "Reentrant GC Cycle?!");
-                abort();
+                fprintf(stderr, "[TuneMyGc.ext] Reentrant GC Cycle?! Disabling!");
+                disabled = 1;
+                while(stat != NULL) {
+                    tunemygc_stat_record *next = (tunemygc_stat_record *)stat->next;
+                    free(stat);
+                    stat = next;
+                }
+                return;
             }
             break;
         case RUBY_INTERNAL_EVENT_GC_EXIT:

--- a/ext/tunemygc/tunemygc_ext.c
+++ b/ext/tunemygc/tunemygc_ext.c
@@ -100,7 +100,10 @@ static VALUE tunemygc_install_gc_tracepoint(VALUE mod)
         rb_tracepoint_disable(tunemygc_tracepoint);
         rb_ivar_set(rb_mTunemygc, id_tunemygc_tracepoint, Qnil);
     }
-    events = RUBY_INTERNAL_EVENT_GC_START | RUBY_INTERNAL_EVENT_GC_END_SWEEP;
+    events = RUBY_INTERNAL_EVENT_GC_START | RUBY_INTERNAL_EVENT_GC_END_MARK | RUBY_INTERNAL_EVENT_GC_END_SWEEP;
+#ifdef RUBY_INTERNAL_EVENT_GC_ENTER
+    events |= RUBY_INTERNAL_EVENT_GC_ENTER | RUBY_INTERNAL_EVENT_GC_EXIT;
+#endif
     tunemygc_tracepoint = rb_tracepoint_new(0, events, tunemygc_gc_hook_i, (void *)0);
     if (NIL_P(tunemygc_tracepoint)) rb_warn("Could not install GC tracepoint!");
     rb_tracepoint_enable(tunemygc_tracepoint);

--- a/ext/tunemygc/tunemygc_ext.c
+++ b/ext/tunemygc/tunemygc_ext.c
@@ -60,7 +60,7 @@ static void tunemygc_invoke_gc_snapshot(void *data)
     }
 }
 
-static void free_current_cycle()
+static void free_whole_cycle()
 {
     tunemygc_stat_record* stat = cycle_head;
     while (stat != NULL) {
@@ -114,7 +114,7 @@ static void tunemygc_gc_hook_i(VALUE tpval, void *data)
             if (cycle_head != NULL) {
                 fprintf(stderr, "[TuneMyGc.ext] Reentrant GC Cycle?! Disabling!");
                 disabled = true;
-                free_current_cycle();
+                free_whole_cycle();
                 return;
             }
             break;
@@ -137,7 +137,7 @@ static void tunemygc_gc_hook_i(VALUE tpval, void *data)
         if (!rb_postponed_job_register(0, tunemygc_invoke_gc_snapshot, (void *)cycle_head)) {
             fprintf(stderr, "[TuneMyGc.ext] Failed enqueing rb_postponed_job_register, disabling!\n");
             disabled = true;
-            free_current_cycle();
+            free_whole_cycle();
         }
         cycle_current = cycle_head = NULL;
     }

--- a/ext/tunemygc/tunemygc_ext.c
+++ b/ext/tunemygc/tunemygc_ext.c
@@ -85,9 +85,9 @@ static void tunemygc_gc_hook_i(VALUE tpval, void *data)
     rb_trace_arg_t *tparg = rb_tracearg_from_tracepoint(tpval);
     rb_event_flag_t flag = rb_tracearg_event_flag(tparg);
 
-    tunemygc_stat_record *stat = ((tunemygc_stat_record*)malloc(sizeof(tunemygc_stat_record)));
+    tunemygc_stat_record *stat = ((tunemygc_stat_record*)calloc(1, sizeof(tunemygc_stat_record)));
     if(stat == NULL) {
-        fprintf(stderr, "[TuneMyGc.ext] malloc'ing tunemygc_stat_record failed, disabling!\n");
+        fprintf(stderr, "[TuneMyGc.ext] calloc'ing tunemygc_stat_record failed, disabling!\n");
         disabled = true;
         return;
     }

--- a/lib/tunemygc.rb
+++ b/lib/tunemygc.rb
@@ -34,6 +34,4 @@ if TuneMyGc.enabled?
     require 'tunemygc/agent'
     TuneMyGc.booted
   end
-else
-  STDERR.puts "[tunemygc] not enabled" unless TuneMyGc.run_silently?
 end

--- a/lib/tunemygc/agent.rb
+++ b/lib/tunemygc/agent.rb
@@ -52,13 +52,7 @@ module TuneMyGc
   end
 
   def recommendations
-    MUTEX.synchronize do
-      require "tunemygc/syncer"
-      syncer = TuneMyGc::Syncer.new
-      config = syncer.sync(snapshotter)
-    end
-  rescue Exception => e
-    log "Config recommendation error (#{e.message})"
+  # no op
   end
 
   extend self

--- a/lib/tunemygc/agent.rb
+++ b/lib/tunemygc/agent.rb
@@ -3,7 +3,6 @@
 require "tunemygc/tunemygc_ext"
 require "tunemygc/interposer"
 require "tunemygc/snapshotter"
-require "logger"
 require "objspace"
 
 module TuneMyGc
@@ -41,7 +40,7 @@ module TuneMyGc
   end
 
   def log(message)
-    logger.info "[tunemygc, ppid: #{Process.ppid}, pid: #{Process.pid}] #{message}"
+    puts "[tunemygc, ppid: #{Process.ppid}, pid: #{Process.pid}] #{message}"
   end
 
   def spy_ids
@@ -65,7 +64,6 @@ module TuneMyGc
   extend self
 
   MUTEX.synchronize do
-    self.logger = Logger.new($stdout)
     self.interposer = TuneMyGc::Interposer.new
     self.snapshotter = TuneMyGc::Snapshotter.new
   end

--- a/lib/tunemygc/snapshotter.rb
+++ b/lib/tunemygc/snapshotter.rb
@@ -6,7 +6,7 @@ module TuneMyGc
   class Snapshotter
     UNITS_OF_WORK = /PROCESSING_STARTED|PROCESSING_ENDED/
     TERMINATED = /TERMINATED/
-    MAX_SAMPLES = (ENV['RUBY_GC_MAX_SAMPLES'] ? Integer(ENV['RUBY_GC_MAX_SAMPLES']) : 2000)
+    MAX_SAMPLES = (ENV['RUBY_GC_MAX_SAMPLES'] ? Integer(ENV['RUBY_GC_MAX_SAMPLES']) : 50000)
 
     attr_reader :buffer
     attr_accessor :unit_of_work

--- a/lib/tunemygc/snapshotter.rb
+++ b/lib/tunemygc/snapshotter.rb
@@ -9,7 +9,7 @@ module TuneMyGc
     MAX_SAMPLES = (ENV['RUBY_GC_MAX_SAMPLES'] ? Integer(ENV['RUBY_GC_MAX_SAMPLES']) : 50000)
 
     attr_reader :buffer
-    attr_accessor :unit_of_work, :reducer
+    attr_accessor :unit_of_work, :reducer, :consumer
     attr_reader :stat_keys
 
     def initialize(buf = Queue.new)
@@ -17,6 +17,7 @@ module TuneMyGc
       @unit_of_work = false
       @stat_keys = GC.stat.keys
       @reducer = nil
+      @consumer = nil
     end
 
     def take(stage, meta = nil)
@@ -52,6 +53,8 @@ module TuneMyGc
     end
 
     def _buffer(snapshot)
+      return consumer.call(snapshot) if consumer
+
       if reducer && size >= MAX_SAMPLES
         reducer.call(self)
       end

--- a/lib/tunemygc/version.rb
+++ b/lib/tunemygc/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module TuneMyGc
-  VERSION = "1.0.69"
+  VERSION = "1.0.69-shopify"
 end


### PR DESCRIPTION
This is probably best reviewed by looking at individual changesets.
This most importantly: 
 - register to all GC hooks
 - fire back into ruby for all events of a cycle
 - lets the consumer deal with the events as below:

```ruby
require 'tunemygc/agent' 
TuneMyGc.snapshotter.consumer = -> (probe) do
  # do stuff with the data
end
TuneMyGc.install_gc_tracepoint
``` 